### PR TITLE
no need to gunzip the .csv

### DIFF
--- a/index.go
+++ b/index.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"compress/gzip"
 	"encoding/csv"
 	"fmt"
 	"io"
@@ -43,8 +44,16 @@ func indexTPB(i bleve.Index) error {
 	batch := bleve.NewBatch()
 	batchCount := 0
 
-	dumpFile, _ := os.Open(*dump)
-	defer dumpFile.Close()
+	gzDumpFile, err := os.Open(*dump)
+	if err != nil {
+		return err
+	}
+	defer gzDumpFile.Close()
+
+	dumpFile, err := gzip.NewReader(gzDumpFile)
+	if err != nil {
+		return err
+	}
 
 	reader := csv.NewReader(dumpFile)
 	reader.FieldsPerRecord = 7

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 var (
 	port = flag.Int("p", 1337, "http listen port")
 	host = flag.String("h", "localhost", "http listen host")
-	dump = flag.String("d", "torrents_mini.csv", "the openbay-db-dump to use")
+	dump = flag.String("d", "torrents_mini.csv.gz", "the openbay-db-dump to use")
 
 	batchSize  = flag.Int("b", 800, "batch size for indexing")
 	indexLimit = flag.Int("l", 0, "index limit")


### PR DESCRIPTION
Hey,

you can read the gzipped file directly if you drop in a [gzip.Reader](http://golang.org/pkg/compress/gzip/#Reader) from `compress/gzip`  between the `os.Open` and `csv.NewReader`. Thereby not wasting precious disk space and you can keep seeding the original file without having both lying around... :wink:

The speed difference is also negligible (I indexed half a million docs with both approaches).
The Indexing is still much heavier.

Btw: you could also drop the `tpbFileHandler` and replace it with [go-bindata-assetfs](https://github.com/elazarl/go-bindata-assetfs) which you can feed to [http.FileServer()](http://golang.org/pkg/net/http/#FileSystem).
